### PR TITLE
Update frontend README

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,41 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# AnyDataNext Frontend
 
-## Getting Started
+This directory contains the Next.js application providing the web interface for AnyDataNext.
 
-First, run the development server:
+## Prerequisites
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+- Node.js 18+ (with `npm`)
+- The backend API running locally on port `8000` (use `./backend-start.sh` from the project root)
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Quick Start
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+1. Install dependencies (only needed once):
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+   ```bash
+   npm install
+   ```
 
-## Learn More
+2. Create a `.env.local` file with the backend URL (optional if using default):
 
-To learn more about Next.js, take a look at the following resources:
+   ```bash
+   echo "NEXT_PUBLIC_BACKEND_URL=http://localhost:8000" > .env.local
+   ```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+3. Start the development server:
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+   ```bash
+   npm run dev
+   ```
 
-## Deploy on Vercel
+   Alternatively you can run `../frontend-start.sh` from the project root which
+   checks that the backend is running before launching the dev server.
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+4. Open <http://localhost:3000> in your browser.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Debugging Tips
+
+- The console running `npm run dev` shows build errors and warnings.
+- Check the browser console for WebSocket messages and API errors.
+- If the UI cannot connect to the backend, verify the `NEXT_PUBLIC_BACKEND_URL`
+  value in `.env.local`.
+


### PR DESCRIPTION
## Summary
- replace default Next.js README with project-specific setup and debugging notes

## Testing
- `npm run lint` *(fails: `next` not found)*